### PR TITLE
Update access-control.rst

### DIFF
--- a/docs/access-control.rst
+++ b/docs/access-control.rst
@@ -185,8 +185,11 @@ Add a view and connect it to urls.
 
     # in apiviews.py
     # ...
+    from django.contrib.auth import authenticate
 
     class LoginView(APIView):
+        permission_classes = ()
+        
         def post(self, request,):
             username = request.data.get("username")
             password = request.data.get("password")


### PR DESCRIPTION
Import authenticate from django.contrib.auth

To POST with a correct username and password, we need  to set the permission_classes to an empty tuple.