### PR TITLE
adds PermissionDenied import statement

### DIFF
--- a/docs/access-control.rst
+++ b/docs/access-control.rst
@@ -266,6 +266,8 @@ We have two remaining things we need to enforce.
 We will do that by overriding :code:`PollViewSet.destroy` and :code:`ChoiceList.post`.
 
 .. code-block:: python
+    # ...
+    from rest_framework.exceptions import PermissionDenied
 
 
     class PollViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
This request adds an import statement for `rest_framework.exceptions.PermissionDenied` to the section covering fine grained access control.