### PR TITLE
Fixed typos for generics view

### DIFF
--- a/docs/views-and-generic-views.rst
+++ b/docs/views-and-generic-views.rst
@@ -248,7 +248,7 @@ The response looks like this
         "poll": 2
     }
 
-You can also retrieve the :code:`Poll` to by doing a :code:`GET` to :code:`/poll/<pk>/`. You should get something like this
+You can also retrieve the :code:`Poll` to by doing a :code:`GET` to :code:`/polls/<pk>/`. You should get something like this
 
 .. code-block:: json
 


### PR DESCRIPTION
There is a typo when you get the poll detail. It should be **/polls/<pk>/** rather than **/poll/<pk>/**