### PR TITLE
Previous user token is not created

### DIFF
--- a/docs/access-control.rst
+++ b/docs/access-control.rst
@@ -301,8 +301,8 @@ We will do that by overriding :code:`PollViewSet.destroy` and :code:`ChoiceList.
                 raise PermissionDenied("You can not create choice for this poll.")
             return super().post(request, *args, **kwargs)
 
-In both cases, we are checkeding the :code:`request.user` against the expected user, and raising
-as :code:`PermissionDenied` if it does not match.
+In both cases, we are checking :code:`request.user` against the expected user, and raising
+a :code:`PermissionDenied` error if it does not match.
 
 You can check this by doing a DELETE on someone elses :code:`Poll`. You will get an error with :code:`HTTP 403 Forbidden` and response.
 
@@ -314,7 +314,7 @@ You can check this by doing a DELETE on someone elses :code:`Poll`. You will get
     }
 
 
-Similarly trying to create choice for someone else's :code:`Poll` will get an error with :code:`HTTP 403 Forbidden` and response
+Similarly, trying to create choice for someone else's :code:`Poll` will get an error with :code:`HTTP 403 Forbidden` and response
 
 .. code-block:: json
 

--- a/docs/access-control.rst
+++ b/docs/access-control.rst
@@ -216,6 +216,14 @@ Add a view and connect it to urls.
         # ...
     ]
 
+WARNING: You have to create a user using the :code:`/user/` endpoint before logging in using the :code:`/login/` endpoint. Using a previously existing user will result in a "User has no auth_token" error because we have not created a token for them. You can create tokens for them manually by using the django shell :code:`$ python manage.py shell`.
+
+    >>> from django.contrib.auth.models import User
+    >>> from rest_framework.authtoken.models import Token
+    >>> user = User.objects.get(pk=pk_of_user_without_token)
+    >>> Token.objects.create(user=user)
+    <Token: e2b9fa2d4ae27fe1fdcf17b6e37711334d07e167>
+
 Do a POST with a correct username and password, and you will get a response like this.
 
 .. code-block:: json


### PR DESCRIPTION
Previously existing users, like the user created using 'createsuperuser' do not have a token. Logging in with those credentials will result in an Internal server error as "User has no auth_token".
I have proposed a solution.