### PR TITLE
add serializer class to CreateVote view

### DIFF
--- a/docs/more-views-and-viewsets.rst
+++ b/docs/more-views-and-viewsets.rst
@@ -42,7 +42,8 @@ We will make changes to :code:`ChoiceList` and :code:`CreateVote`, because the :
 
 
     class CreateVote(APIView):
-
+        serializer_class = VoteSerializer
+        
         def post(self, request, pk, choice_pk):
             voted_by = request.data.get("voted_by")
             data = {'choice': choice_pk, 'poll': pk, 'voted_by': voted_by}


### PR DESCRIPTION
adding serializer class to CreateVote view to avoid `'CreateVote' should either include a 'serializer_class' attribute, or override the 'get_serializer_class()' method.`