### PR TITLE
changes in url.py for router.register()

### DIFF
--- a/docs/more-views-and-viewsets.rst
+++ b/docs/more-views-and-viewsets.rst
@@ -166,7 +166,7 @@ This is what it will look like:
 
 
     router = DefaultRouter()
-    router.register('polls', PollViewSet, base_name='polls')
+    router.register('polls', PollViewSet, basename='polls')
 
 
     urlpatterns = [


### PR DESCRIPTION
the right syntax is  basename in urls.py when we use router.register()