### PR TITLE
Router argument/method renamed to use `basename`

### DIFF
--- a/docs/more-views-and-viewsets.rst
+++ b/docs/more-views-and-viewsets.rst
@@ -166,7 +166,7 @@ This is what it will look like:
 
 
     router = DefaultRouter()
-    router.register('polls', PollViewSet, base_name='polls')
+    router.register('polls', PollViewSet, basename='polls')
 
 
     urlpatterns = [


### PR DESCRIPTION
`base_name` is deprecated in later versions of DRF.
https://github.com/encode/django-rest-framework/pull/5990

The Router.register base_name argument has been renamed in favor of `basename`.